### PR TITLE
Removed Validation from purposeIds on itinerary screen#26

### DIFF
--- a/src/main/java/com/example/triplanner/controller/TripsController.java
+++ b/src/main/java/com/example/triplanner/controller/TripsController.java
@@ -154,7 +154,7 @@ public class TripsController {
 				break;
 			}
 			rowSequence.add(i * 2 + 1);
-			purposeIds.add(0);
+			purposeIds.add(2);
 			startTime.add(tripsNewForm.getArrivalTimes().get(i));
 			endTime.add(tripsNewForm.getDepartTimes().get(i + 1));
 			departurePrefectureIds.add(null);
@@ -257,6 +257,8 @@ public class TripsController {
 			model.addAttribute("publicOptions", publicOptions);
 			List<Purpose> purposes = purposeRepository.findAllByOrderById();
 			model.addAttribute("purposes", purposes);
+			//purposeIdのバリデーションエラーメッセージ
+			model.addAttribute("purposeIdsMessage", "行動のプルダウンを全て選択してください");
 
 			return "trips/itinerary";
 		}

--- a/src/main/resources/templates/trips/itinerary.html
+++ b/src/main/resources/templates/trips/itinerary.html
@@ -69,23 +69,13 @@
 											<input type="hidden" name=rowSequences
 												th:value="${#object.rowSequences[i]}">
 											<td th:text="${#temporals.day(#object.startTimes[i])}"></td>
-											<td><select name="purposeIds" class="form-select" required>
-													<th:block th:if="${#object.purposeIds[1] == 0}">
-														<option value="" selected hidden>選択してください</option>
-														<th:block th:each="purpose : ${purposes}">
-															<option th:value="${purpose.id}"
-																th:text="${purpose.purpose}">
-															</option>
-														</th:block>
-													</th:block>
-													<th:block th:if="${#object.purposeIds[1] != 0}">
+											<td><select name="purposeIds" class="form-select">
 														<th:block th:each="purpose : ${purposes}">
 															<option th:value="${purpose.id}"
 																th:text="${purpose.purpose}"
 																th:selected="${purpose.id == #object.purposeIds[i]}">
 															</option>
 														</th:block>
-													</th:block>
 												</select></td>
 											<td th:text="${#temporals.format(#object.startTimes[i], 'HH:mm')}">00:00
 											</td>
@@ -115,9 +105,7 @@
 						</table>
 					</div>
 				</div> <!-- row閉じ ここまで旅程表-->
-<!--				<p th:if="${#fields.hasErrors('purposeIds')}" th:errors="*{purposeIds}" th:errorclass="error-message">-->
-<!--				</p>-->
-				<div class="mb-3">
+				<div class="row mb-3">
 					<div class="col-md-4">
 						<label for="tripTitle" class="form-label">旅のタイトル</label>
 						<div class="w-100"></div>
@@ -128,7 +116,6 @@
 						</p>
 					</div>
 				</div>
-
 				<!-- タグをDBから取得して表示する-->
 				<div class="row mb-3">
 					<label class="form-label">タグ</label>


### PR DESCRIPTION
旅程作成画面の行動内容(purposeIds)を旅程画面から外す。
・purposeIdsの初期値を1(移動)、2(観光)に変更
（観光の確立が高いと思われるため、観光を初期値に指定）
・旅程作成画面itinerary.htmlのpurposeIdsをタグでValidateしていたが削除した。
（戻るボタンを押したときも行動内容の入力を求められるため）