### PR TITLE
Validato change for ArrivalTimes and PlaceNames#34

### DIFF
--- a/src/main/java/com/example/triplanner/validation/constraints/ArrivalTimesNotNullValidator.java
+++ b/src/main/java/com/example/triplanner/validation/constraints/ArrivalTimesNotNullValidator.java
@@ -14,12 +14,14 @@ public class ArrivalTimesNotNullValidator implements ConstraintValidator<Arrival
 	
 	@Override
 	public boolean isValid(List<LocalDateTime> arrivalTimes, ConstraintValidatorContext context) {
-		if (arrivalTimes.size() == 0) {
+		if (arrivalTimes == null) {
+			return true;//確認画面から戻る時にtrue。場所が1カ所のみもtrueだが場所の個数のValidateでfalseになる。
+		} else if (arrivalTimes.size() == 0) {
 			return false;
-		} else if (arrivalTimes.get(0) == null) {
-			return false;
+		} else if (arrivalTimes.get(0) != null) {
+			return true;
 		}
-		return true;
+		return false;
 	}
 
 }

--- a/src/main/java/com/example/triplanner/validation/constraints/PlaceNamesLengthValidator.java
+++ b/src/main/java/com/example/triplanner/validation/constraints/PlaceNamesLengthValidator.java
@@ -5,21 +5,23 @@ import java.util.List;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
-public class PlaceNamesLengthValidator implements ConstraintValidator<PlaceNamesLength, List<String>>{
-	
+public class PlaceNamesLengthValidator implements ConstraintValidator<PlaceNamesLength, List<String>> {
+
 	int min;
-	
+
 	@Override
 	public void initialize(PlaceNamesLength annotation) {
 		this.min = annotation.min();
 	}
-	
+
 	@Override
 	public boolean isValid(List<String> placeNames, ConstraintValidatorContext context) {
-		if (placeNames.size() < this.min) {
-			return false;
+		if (placeNames == null) {
+			return true;
+		} else if (placeNames.size() >= this.min) {
+			return true;
 		}
-		return true;
+		return false;
 	}
 
 }


### PR DESCRIPTION
旅程確認画面から旅程作成画面に戻るときにエラーが発生する。
原因は旅作成画面から旅程作成画面に進むときのValidationで、フィールドがnullの物に対してList.size()を行っていたため。
旅作成画面から旅程作成画面に進むときのarrivalTimesの状態は、下記のようにリクエストで変化する。
| リクエストの状態＼List                                                          | arrivalTimes     | arrivalTimes.size()            | arrivalTimes.get(0)              | 
| ------------------------------------------------------------------------------- | ---------------- | ------------------------------ | -------------------------------- | 
| arrivalTimesがkeyに無い                                                         | null             | NullPointerException at size() | NullPointerException at get(int) | 
| keyはあるが、valueは無し<br>（arrivalTimes=)                                    | []               | 0                              | IndexOutOfBoundsException        | 
| key、value共に有りが1ペア<br>（arrivalTimes=value1）                            | [value1]         | 1                              | value1                           | 
| key、value共に有りが2ペア<br>（arrivalTimes=value1、<br>　arrivalTimes=value2） | [value1, value2] | 2                              | value1                           | 
| keyは2つあるが、どちらもvalueは無し<br>（arrivalTimes=<br>　arrivalTimes＝）    | [null, null]     | 2                              | null                             | 

上記の結果ArrivalTimesNotNullValidatorとPlaceNamesLengthValidatorを下記内容に変更。
・ArrivalTimesNotNullValidator
1. arrivalTimes == null → return true;
旅程確認画面から旅作成画面に戻る時
旅作成画面の場所が1カ所の時(keyにarrivalTimesが無い時)
2. arrivalTimes.size() == 0 → return false;
旅作成画面の場所が2カ所でvalueが有る時
3. arrivalTimes.get(0) != null → return true;
旅作成画面の場所が2カ所以上でvalueが有る時
4. 上記以外 → return false;
旅作成画面の場所が2カ所以上でvalueが無い時

・PlaceNamesLengthValidator
1. placeNames == null → return true;
旅程確認画面から旅作成画面に戻る時
2. placeNames.size() >= this.min  → return true;
旅作成画面の場所がmin以上の時
3.上記以外 → retrurn false;
旅作成画面の場所がmin未満の時